### PR TITLE
Edit functioanlity data logs

### DIFF
--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
     path("employees/", views.employee_details_view, name="employee_list"),
     path("employees/<int:id>/", views.employee_details_view, name="employee_detail"),
     path("raw-data-logs/", views.raw_data_logs_view, name="raw_data_logs"),
+    path(
+        "raw-data-logs/<int:id>/",
+        views.raw_data_logs_detail_view,
+        name="raw_data_logs_detail",
+    ),
     # JSON API endpoint for weekly summary data
     path("weekly-summary/", views.weekly_summary_view, name="weekly_summary_view"),
     # HTML page that uses JS to fetch from the above API

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -179,7 +179,7 @@ def raw_data_logs_detail_view(request, id):
         return JsonResponse(data, safe=False)
 
     if request.method == "PUT":
-        required_fields = ["employee_id", "clock_in_time", "clock_out_time"]
+        required_fields = ["login_time", "logout_time"]
         # Update the Activity
         data = request.data
         missing_fields = [field for field in required_fields if field not in data]

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -88,6 +88,7 @@ def raw_data_logs_view(request):
 
                 data.append(
                     {
+                        "id": act.id,
                         "staff_name": staff_name,
                         "login_time": (
                             act.login_time.strftime("%H:%M")
@@ -124,6 +125,94 @@ def raw_data_logs_view(request):
             # Return the template with CSRF token
             get_token(request)
             return render(request, "auth_app/raw_data_logs.html")
+
+
+@api_view(["GET", "PUT"])
+@renderer_classes([JSONRenderer])
+def raw_data_logs_detail_view(request, id):
+    """
+    Handle retrieval (GET) and updates (PUT) for a single Activity record.
+    """
+    # Attempt to fetch the activity by ID
+    activity = get_object_or_404(Activity, id=id)
+
+    if request.method == "GET":
+        # Return JSON data for a single Activity
+        staff_name = (
+            f"{activity.employee_id.first_name} {activity.employee_id.last_name}"
+        )
+        hours_decimal = (
+            activity.shift_length_mins / 60.0 if activity.shift_length_mins else 0.0
+        )
+
+        data = {
+            "id": activity.id,
+            "employee_id": activity.employee_id.id,  # optional if you need
+            "staff_name": staff_name,
+            "login_time": (
+                activity.login_time.strftime("%Y-%m-%dT%H:%M:%S")
+                if activity.login_time
+                else None
+            ),
+            "logout_time": (
+                activity.logout_time.strftime("%Y-%m-%dT%H:%M:%S")
+                if activity.logout_time
+                else None
+            ),
+            "is_public_holiday": activity.is_public_holiday,
+            "login_timestamp": (
+                activity.login_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
+                if activity.login_timestamp
+                else None
+            ),
+            "logout_timestamp": (
+                activity.logout_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
+                if activity.logout_timestamp
+                else None
+            ),
+            "deliveries": activity.deliveries,
+            "shift_length_mins": activity.shift_length_mins,
+            "hours_worked": f"{hours_decimal:.2f}",
+        }
+
+        return JsonResponse(data, safe=False)
+
+    if request.method == "PUT":
+        # Update the Activity
+        data = request.data
+
+        # For example, if you decide to let the manager update the rounded times:
+        login_time_str = data.get("login_time")
+        logout_time_str = data.get("logout_time")
+
+        # Parse the string times if provided (assuming they come in as ISO8601, e.g. "2025-01-01T14:30:00")
+        if login_time_str:
+            activity.login_time = datetime.strptime(login_time_str, "%Y-%m-%dT%H:%M:%S")
+        if logout_time_str:
+            activity.logout_time = datetime.strptime(
+                logout_time_str, "%Y-%m-%dT%H:%M:%S"
+            )
+
+        # is_public_holiday, deliveries, etc.
+        if "is_public_holiday" in data:
+            activity.is_public_holiday = data["is_public_holiday"]
+
+        if "deliveries" in data:
+            activity.deliveries = data["deliveries"]
+
+        # Optionally, recalc shift_length_mins (if you want to do that automatically)
+        # Only if both login_time and logout_time exist:
+        if activity.login_time and activity.logout_time:
+            delta = activity.logout_time - activity.login_time
+            activity.shift_length_mins = int(delta.total_seconds() // 60)
+
+        # Save the changes
+        activity.save()
+
+        return JsonResponse({"message": "Activity updated successfully"})
+
+    # Fallback
+    return JsonResponse({"error": "Invalid request"}, status=400)
 
 
 @api_view(["GET", "PUT", "POST"])

--- a/src/django/auth_app/templates/auth_app/raw_data_logs.html
+++ b/src/django/auth_app/templates/auth_app/raw_data_logs.html
@@ -1,28 +1,50 @@
 {% extends "auth_app/base.html" %}
 {% block title %}Pizza Clock-in || Raw Data Logs{% endblock %}
+
 {% block content %}
-
 <h1>Raw Data Logs</h1>
-
 <button onclick="location.href='/manager_dashboard/'">Back to Dashboard</button>
 
 <table id="rawDataTable">
-    <thead>
-        <tr>
-            <th>Staff Name</th>
-            <th>Rounded Login Time</th>
-            <th>Rounded Logout Time</th>
-            <th>Is Public Holiday</th>
-            <th>Exact Login Timestamp</th>
-            <th>Exact Logout Timestamp</th>
-            <th>Deliveries</th>
-            <th>Hours Worked</th>
-        </tr>
-    </thead>
-    <tbody>
-        <!-- Rows will be populated dynamically -->
-    </tbody>
+  <thead>
+    <tr>
+      <th>Staff Name</th>
+      <th>Rounded Login Time</th>
+      <th>Rounded Logout Time</th>
+      <th>Is Public Holiday</th>
+      <th>Exact Login Timestamp</th>
+      <th>Exact Logout Timestamp</th>
+      <th>Deliveries</th>
+      <th>Hours Worked</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
 </table>
 
-{% endblock %}
+<!-- EDIT Activity Modal -->
+<div id="editActivityModal" class="modal" style="display: none;">
+  <div class="modal-content">
+    <h2>Edit Activity</h2>
+    <form id="editActivityForm">
+      {% csrf_token %}
+      <input type="hidden" id="editActivityId">
 
+      <label for="editLoginTime">Login Time (rounded):</label>
+      <input type="datetime-local" id="editLoginTime">
+
+      <label for="editLogoutTime">Logout Time (rounded):</label>
+      <input type="datetime-local" id="editLogoutTime">
+
+      <label for="editIsPublicHoliday">Is Public Holiday?</label>
+      <input type="checkbox" id="editIsPublicHoliday" value="true">
+
+      <label for="editDeliveries">Deliveries:</label>
+      <input type="number" id="editDeliveries" min="0">
+
+      <button type="submit">Save Changes</button>
+      <button type="button" id="closeEditModal">Cancel</button>
+    </form>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
PR introduces functionality that allows managers to edit individual raw data logs directly from the "Raw data logs" page. The implementation used is similar to that of the employee details page which also has an edit feature, however, the js has been moved into scripts.js rather than inline. 

New Endpoint added for activity (raw_data_logs_detail_view): 
GET: Fetches detailed information for a specific Activity record by ID.
PUT: Updates an Activity record, allowing changes to:
- Login/Logout times.
- Public holiday status.
- Deliveries count.
- Automatically recalculates shift_length_mins if both login and logout times are provided.
- Ensures proper datetime parsing to handle the ISO 8601 format used in the front-end.

Included a modal (#editActivityModal) for editing raw data logs:
- Fields for login/logout times, public holiday status, and deliveries.
- Input validation for datetime and numeric fields.