### PR TITLE
Secure pages

### DIFF
--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -241,6 +241,7 @@ def employee_details_view(request, id=None):
         {"Error": "Invalid request"}, status=status.HTTP_400_BAD_REQUEST
     )
 
+
 @manager_required
 def employee_details_page(request):
     """
@@ -623,6 +624,7 @@ def reset_summary_view(request):
         {"message": "Weekly summary reset successfully", "reset_date": today_str},
         status=status.HTTP_200_OK,
     )
+
 
 @manager_required
 def weekly_summary_page(request):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -28,6 +28,7 @@ logger = logging.getLogger("api")
 
 
 @api_view(["GET"])
+@manager_required
 def list_users_name_view(request):
     """
     API view to fetch a list of users with their IDs and full names.
@@ -74,6 +75,7 @@ def list_users_name_view(request):
 
 
 @api_view(["GET"])
+@manager_required
 @renderer_classes([JSONRenderer])
 def raw_data_logs_view(request):
     if request.method == "GET":
@@ -133,7 +135,7 @@ def raw_data_logs_view(request):
 
 @api_view(["GET", "PUT", "POST"])
 @renderer_classes([JSONRenderer])
-# @manager_required
+@manager_required
 def employee_details_view(request, id=None):
     logger.error(f"test: {request.user}")
     if request.method == "GET":
@@ -239,7 +241,7 @@ def employee_details_view(request, id=None):
         {"Error": "Invalid request"}, status=status.HTTP_400_BAD_REQUEST
     )
 
-
+@manager_required
 def employee_details_page(request):
     """
     View to render the employee details HTML page.
@@ -490,6 +492,7 @@ def clocked_state_view(request, id):
 
 @api_view(["GET"])
 @renderer_classes([JSONRenderer])
+@manager_required
 def weekly_summary_view(request):
     start_date_str = request.query_params.get("start_date")
     end_date_str = request.query_params.get("end_date")
@@ -591,6 +594,7 @@ def weekly_summary_view(request):
 
 @api_view(["POST"])
 @renderer_classes([JSONRenderer])
+@manager_required
 def reset_summary_view(request):
     # If a new date is provided in the POST, use it, otherwise today
     new_date_str = request.data.get("new_reset_date")
@@ -620,13 +624,14 @@ def reset_summary_view(request):
         status=status.HTTP_200_OK,
     )
 
-
+@manager_required
 def weekly_summary_page(request):
     # Return the HTML template
     return render(request, "auth_app/weekly_summary.html")
 
 
 @api_view(["POST", "PUT"])
+@manager_required
 def change_pin(request, id):
     try:
         # Get new pin
@@ -690,6 +695,7 @@ def change_pin(request, id):
 
 
 @api_view(["POST", "PUT"])
+@manager_required
 def active_employee_account(request, id):
     try:
         # Get new pin

--- a/src/django/auth_app/urls.py
+++ b/src/django/auth_app/urls.py
@@ -7,7 +7,6 @@ urlpatterns = [
     path("login/", views.login_view, name="login"),
     path("manager_login/", views.manager_login, name="manager_login"),
     path("logout/", views.logout_view, name="logout"),
-    # path("logout/", LogoutView.as_view(next_page="/"), name="logout"),
     path("manager_dashboard/", views.manager_dashboard, name="manager_dashboard"),
     path("employee_login/", views.employee_login, name="employee_login"),
     path("employee_dashboard/", views.employee_dashboard, name="employee_dashboard"),

--- a/src/django/auth_app/utils.py
+++ b/src/django/auth_app/utils.py
@@ -1,36 +1,15 @@
 from functools import wraps
 from django.shortcuts import redirect
 
-
-# def manager_required(view_func):
-#     """
-#     Decorator to ensure the user is an authenticated manager.
-#     """
-
-#     @wraps(view_func)
-#     def _wrapped_view(request, *args, **kwargs):
-#         user_id = request.session.get("user_id")
-#         is_manager = request.session.get("is_manager", False)
-#         print(f"Decorator check: user_id={user_id}, is_manager={is_manager}")  # Debug
-
-#         if not user_id or not is_manager:
-#             return redirect("manager_login")  # Redirect to login if not a manager
-#         return view_func(request, *args, **kwargs)
-
-#     return _wrapped_view
-
-
 def manager_required(view_func):
+    """
+    Decorator to ensure the user is an authenticated manager.
+    """
     @wraps(view_func)
     def _wrapped_view(request, *args, **kwargs):
-        # Check if the user is authenticated
-        if not request.user.is_authenticated:
-            return redirect("manager_login")  # Redirect to manager login page
-
-        # Check if the user is a manager
-        if not hasattr(request.user, "is_manager") or not request.user.is_manager:
-            return redirect("manager_login")  # Redirect if not a manager
-
+        user_id = request.session.get("user_id")
+        is_manager = request.session.get("is_manager", False)
+        if not user_id or not is_manager:
+            return redirect("manager_login")  # Redirect to login if not a manager
         return view_func(request, *args, **kwargs)
-
     return _wrapped_view

--- a/src/django/auth_app/utils.py
+++ b/src/django/auth_app/utils.py
@@ -1,10 +1,12 @@
 from functools import wraps
 from django.shortcuts import redirect
 
+
 def manager_required(view_func):
     """
     Decorator to ensure the user is an authenticated manager.
     """
+
     @wraps(view_func)
     def _wrapped_view(request, *args, **kwargs):
         user_id = request.session.get("user_id")
@@ -12,4 +14,5 @@ def manager_required(view_func):
         if not user_id or not is_manager:
             return redirect("manager_login")  # Redirect to login if not a manager
         return view_func(request, *args, **kwargs)
+
     return _wrapped_view

--- a/src/django/auth_app/views.py
+++ b/src/django/auth_app/views.py
@@ -30,7 +30,7 @@ def manager_login(request):
             # Log the user in by setting session data
             request.session["user_id"] = user.id
             request.session["is_manager"] = user.is_manager
-            logger
+            logger.debug(f"Session data: {request.session.items()}")
             return redirect("manager_dashboard")
         else:
             messages.error(request, "Invalid Details")
@@ -43,8 +43,9 @@ def logout_view(request):
     return redirect("manager_login")
 
 
-# @manager_required
+@manager_required
 def manager_dashboard(request):
+    logger.debug(f"Session data: {request.session.items()}")
     user_id = request.session.get("user_id")
     user = User.objects.get(id=user_id)  # Retrieve the logged-in user's details
     return render(request, "auth_app/manager_dashboard.html", {"user": user})
@@ -58,3 +59,4 @@ def employee_login(request):
 def employee_dashboard(request):
     # Render employee dashboard
     return render(request, "auth_app/employee_dashboard.html")
+

--- a/src/django/auth_app/views.py
+++ b/src/django/auth_app/views.py
@@ -59,4 +59,3 @@ def employee_login(request):
 def employee_dashboard(request):
     # Render employee dashboard
     return render(request, "auth_app/employee_dashboard.html")
-


### PR DESCRIPTION
Added security for the manager pages/endpoints

- Essentially working by checking if the user accessing the page/enpoint is A) a valid user with a valid user id and B) has their the is_manager boolean set to true
- This may require further testing but it does seem to be working
- If a page is accessed without being logged in, it will redirect to the manager log in page 

EDIT:
- Cameron will need to update the automated tests as they will now fail as the testing client is making unauthenticated requests to manager pages