### PR TITLE
Legacy account summary table design

### DIFF
--- a/src/django/api/controllers.py
+++ b/src/django/api/controllers.py
@@ -74,13 +74,14 @@ def get_store_employee_names(
     return {user.id: f"{user.first_name} {user.last_name}" for user in users}
 
 
-def handle_clock_in(employee_id: int, store_id: int) -> Activity:
+def handle_clock_in(employee_id: int, store_id: int, manual: bool = False) -> Activity:
     """
     Handles clocking in an employee by ID.
 
     Args:
         employee_id (int): The employee's ID.
         store_id (int): The store's ID for which the clocking event will register.
+        manual (bool) = False: Whether the clock in is requested via manual clocking page or not. For logging purposes only.
 
     Returns:
         Activity: An activity object containing the information about the clock in.
@@ -133,10 +134,10 @@ def handle_clock_in(employee_id: int, store_id: int) -> Activity:
             )
 
             logger.info(
-                f"Employee ID {employee.id} ({employee.first_name} {employee.last_name}) created a new ACTIVITY (CLOCKED IN) under the store ID {store.id} [{store.code}]."
+                f"Employee ID {employee.id} ({employee.first_name} {employee.last_name}) created a new ACTIVITY (CLOCKED IN) under the store ID {store.id} [{store.code}]{' via MANUAL CLOCKING' if manual else ''}."
             )
             logger.debug(
-                f"[CREATE: ACTIVITY (ID: {activity.id})] [CLOCK-IN] Employee ID {employee.id} ({employee.first_name} {employee.last_name}) -- Store ID: {store.id} [{store.code}] -- Login: {activity.login_time} ({activity.login_timestamp}) -- PUBLIC HOLIDAY: {activity.is_public_holiday}"
+                f"[CREATE: ACTIVITY (ID: {activity.id})] [{'MANUAL ' if manual else ''}CLOCK-IN] Employee ID {employee.id} ({employee.first_name} {employee.last_name}) -- Store ID: {store.id} [{store.code}] -- Login: {activity.login_time} ({activity.login_timestamp}) -- PUBLIC HOLIDAY: {activity.is_public_holiday}"
             )
             return activity
 
@@ -159,7 +160,9 @@ def handle_clock_in(employee_id: int, store_id: int) -> Activity:
         raise e
 
 
-def handle_clock_out(employee_id: int, deliveries: int, store_id: int) -> Activity:
+def handle_clock_out(
+    employee_id: int, deliveries: int, store_id: int, manual: bool = False
+) -> Activity:
     """
     Handles clocking out an employee by ID.
 
@@ -167,6 +170,7 @@ def handle_clock_out(employee_id: int, deliveries: int, store_id: int) -> Activi
         employee_id (int): The employee's ID.
         deliveries (int): Number of deliveries made during the shift.
         store_id (int): The store's ID for which the clocking event will register.
+        manual (bool) = False: Whether the clock out is requested via manual clocking page or not. For logging purposes only.
 
     Returns:
         Activity: An activity object containing the information about the clock out.
@@ -215,10 +219,10 @@ def handle_clock_out(employee_id: int, deliveries: int, store_id: int) -> Activi
             activity.save()
 
             logger.info(
-                f"Employee ID {employee.id} ({employee.first_name} {employee.last_name}) created a new ACTIVITY (CLOCKED IN) under the store ID {store.id} [{store.code}]."
+                f"Employee ID {employee.id} ({employee.first_name} {employee.last_name}) created a new ACTIVITY (CLOCKED IN) under the store ID {store.id} [{store.code}]{' via MANUAL CLOCKING' if manual else ''}."
             )
             logger.debug(
-                f"[UPDATE: ACTIVITY (ID: {activity.id})] [CLOCK-OUT] Employee ID {employee.id} ({employee.first_name} {employee.last_name}) -- Store ID: {store.id} [{store.code}] -- Login: {activity.login_time} ({activity.login_timestamp}) -- Logout: {activity.logout_time} ({activity.logout_timestamp}) -- Deliveries: {activity.deliveries} -- Shift Length: {activity.shift_length_mins}mins -- PUBLIC HOLIDAY: {activity.is_public_holiday}"
+                f"[UPDATE: ACTIVITY (ID: {activity.id})] [{'MANUAL ' if manual else ''}CLOCK-OUT] Employee ID {employee.id} ({employee.first_name} {employee.last_name}) -- Store ID: {store.id} [{store.code}] -- Login: {activity.login_time} ({activity.login_timestamp}) -- Logout: {activity.logout_time} ({activity.logout_timestamp}) -- Deliveries: {activity.deliveries} -- Shift Length: {activity.shift_length_mins}mins -- PUBLIC HOLIDAY: {activity.is_public_holiday}"
             )
             return activity
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -797,6 +797,7 @@ def list_all_employee_details(request):
                 "dob": emp.birth_date.strftime("%d/%m/%Y") if emp.birth_date else None,
                 "pin": emp.pin,
                 "is_active": emp.is_active,
+                "is_manager": emp.is_manager,
             }
             for emp in employees
         ]

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1233,7 +1233,6 @@ def modify_account_information(request, id=None):
 
         # Validate and update DOB
         if dob:
-            logger.critical("PASSED")
             if not user.is_manager:
                 return Response(
                     {"Error": "Not authorised to modify your account date of birth."},

--- a/src/django/auth_app/forms.py
+++ b/src/django/auth_app/forms.py
@@ -189,7 +189,7 @@ class ManualClockingForm(forms.Form):
         label="Store PIN",
         required=True,
         max_length=255,
-        widget=forms.TextInput(
+        widget=forms.PasswordInput(
             attrs={
                 "placeholder": "Store PIN",
                 "maxlength": "255",
@@ -201,7 +201,7 @@ class ManualClockingForm(forms.Form):
     employee_pin = forms.CharField(
         label="Employee PIN",
         required=True,
-        widget=forms.TextInput(
+        widget=forms.PasswordInput(
             attrs={
                 "placeholder": "Employee PIN",
                 "class": "w-100 form-control form-control-lg",

--- a/src/django/auth_app/forms.py
+++ b/src/django/auth_app/forms.py
@@ -71,7 +71,7 @@ class AccountSetupForm(forms.Form):
         ),
     )
     phone_number = forms.CharField(
-        label="Phone Number (Optional)",
+        label="Phone Number",
         required=False,
         widget=forms.TextInput(
             attrs={
@@ -81,7 +81,7 @@ class AccountSetupForm(forms.Form):
         ),
     )
     birth_date = forms.DateField(
-        label="Date of Birth (Optional)",
+        label="Date of Birth",
         required=False,
         widget=forms.DateInput(
             attrs={

--- a/src/django/auth_app/forms.py
+++ b/src/django/auth_app/forms.py
@@ -101,6 +101,16 @@ class AccountSetupForm(forms.Form):
             }
         ),
     )
+    password_copy = forms.CharField(
+        label="Retype Password",
+        required=True,
+        widget=forms.PasswordInput(
+            attrs={
+                "placeholder": "Retype your Password",
+                "class": "w-100 form-control form-control-lg",
+            }
+        ),
+    )
 
     def clean_email(self):
         email = self.cleaned_data.get("email", "").strip().lower()
@@ -166,6 +176,12 @@ class AccountSetupForm(forms.Form):
                 "Password must contain at least one uppercase letter, one lowercase letter, and one number."
             )
         return password
+
+    def clean_password_copy(self):
+        password = self.cleaned_data.get("password", "")
+        password_copy = self.cleaned_data.get("password_copy", "")
+        if password != password_copy:
+            raise ValidationError("Both password fields must match.")
 
 
 class ManualClockingForm(forms.Form):

--- a/src/django/auth_app/forms.py
+++ b/src/django/auth_app/forms.py
@@ -101,7 +101,7 @@ class AccountSetupForm(forms.Form):
             }
         ),
     )
-    password_copy = forms.CharField(
+    retype_password = forms.CharField(
         label="Retype Password",
         required=True,
         widget=forms.PasswordInput(
@@ -177,10 +177,10 @@ class AccountSetupForm(forms.Form):
             )
         return password
 
-    def clean_password_copy(self):
+    def clean_retype_password(self):
         password = self.cleaned_data.get("password", "")
-        password_copy = self.cleaned_data.get("password_copy", "")
-        if password != password_copy:
+        retype_password = self.cleaned_data.get("retype_password", "")
+        if password != retype_password:
             raise ValidationError("Both password fields must match.")
 
 

--- a/src/django/auth_app/models.py
+++ b/src/django/auth_app/models.py
@@ -28,12 +28,12 @@ class User(models.Model):
 
     def __str__(self):
         role = ""
-        if self.is_manager:
-            role = " - MANAGER"
         if self.is_hidden:
             if self.is_manager:
                 role = " - MANAGER/HIDDEN"
             role = " - HIDDEN"
+        elif self.is_manager:
+            role = " - MANAGER"
 
         return f"[{self.id}] {self.first_name} {self.last_name} ({self.email}){role}"
 
@@ -242,12 +242,13 @@ class StoreUserAccess(models.Model):
 
     def __str__(self):
         role = "EMPLOYEE"
-        if self.user.is_manager:
-            role = "MANAGER"
         if self.user.is_hidden:
+            role = "HIDDEN"
             if self.user.is_manager:
                 role = "MANAGER/HIDDEN"
             role = "HIDDEN"
+        elif self.user.is_manager:
+            role = "MANAGER"
 
         return f"{self.user.first_name} {self.user.last_name} [{self.user.id}] → {self.store.code} ({role})"
 

--- a/src/django/auth_app/static/js/account_summary.js
+++ b/src/django/auth_app/static/js/account_summary.js
@@ -69,7 +69,7 @@ function updateSummaryTable() {
         $('#summaryTable tbody').html("");
         $.each(summaries, function(index, sum) {
           // Add table information based on the selected style
-          addTableRowInformaiton(legacyStyle, sum);
+          addTableRowInformation(legacyStyle, sum);
         });
         // No need to update edit buttons as that is done dynamically
         setPaginationValues(req.offset, req.total); // Set pagination values
@@ -95,7 +95,7 @@ function updateSummaryTable() {
 }
 
 
-function addTableRowInformaiton(legacyStyle, sum) {
+function addTableRowInformation(legacyStyle, sum) {
   // Set row colour based on desc priority: resigned from store (red), inactive acc (yellow), manager (blue), then white 
   const rowColour = sum.acc_resigned ? 'table-danger' : (!sum.acc_active ? 'table-warning' : (sum.acc_manager ? 'table-info' : ''));
 

--- a/src/django/auth_app/static/js/account_summary.js
+++ b/src/django/auth_app/static/js/account_summary.js
@@ -1,9 +1,9 @@
 $(document).ready(function() {
-  // Update store selection component
-  populateStoreSelection();
-
   // Set default date for table controls
   setDefaultDateControls();
+
+  // Initial table update
+  updateSummaryTable();
 
   // Populate the table with all users once the stores have loaded completely
   $('#storeSelectDropdown').on('change', () => {

--- a/src/django/auth_app/static/js/account_summary.js
+++ b/src/django/auth_app/static/js/account_summary.js
@@ -28,6 +28,7 @@ function updateSummaryTable() {
   const sort = $('#sortFields input[type="radio"]:checked').val();
   const ignoreNoHrs = $('#ignoreNoHours').is(':checked');
   const filter = $('#filterNames').val();
+  const legacyStyle = $('#legacyStyle').is(':checked');
 
   $.ajax({
     url: `${window.djangoURLs.listAccountSummaries}?offset=${getPaginationOffset()}&limit=${getPaginationLimit()}&store_id=${getSelectedStoreID()}&start=${startDate}&end=${endDate}&sort=${sort}&ignore_no_hours=${ignoreNoHrs}&filter=${filter}`,
@@ -42,32 +43,33 @@ function updateSummaryTable() {
     success: function(req) {
       hideSpinner();
 
-      const $summaryTable = $('#summaryTable tbody');
       const summaries = req.results || [];
+
+      if (legacyStyle) {
+         $('#legacySummaryTable').removeClass('d-none');
+         $('#summaryTable').addClass('d-none');
+      } else {
+        $('#legacySummaryTable').addClass('d-none');
+         $('#summaryTable').removeClass('d-none');
+      }
 
       // If there are no users returned
       if (summaries.length <= 0) {
-          $summaryTable.html(`<tr><td colspan="7" class="table-danger">No Summaries Found</td></tr>`);
+          if (legacyStyle) {
+            $('#legacySummaryTable tbody').html(`<tr><td colspan="1" class="table-danger">No Summaries Found</td></tr>`);
+          } else {
+            $('#summaryTable tbody').html(`<tr><td colspan="7" class="table-danger">No Summaries Found</td></tr>`);
+          }
           showNotification("Obtained no summaries when updating table.", "danger");
           setPaginationValues(0, 1); // Set pagination values to indicate an empty table
 
       } else {
-        $summaryTable.html(""); // Reset inner HTML
+        // Reset inner HTML
+        $('#legacySummaryTable tbody').html("");
+        $('#summaryTable tbody').html("");
         $.each(summaries, function(index, sum) {
-          // Set row colour based on desc priority: resigned from store (red), inactive acc (yellow), manager (blue), then white 
-          const rowColour = sum.acc_resigned ? 'table-danger' : (!sum.acc_active ? 'table-warning' : (sum.acc_manager ? 'table-info' : ''));
-          const row = `
-            <tr class="${rowColour}">
-              <td>${sum.name}</td>
-              <td>${sum.hours_weekday}</td>
-              <td>${sum.hours_weekend}</td>
-              <td>${sum.hours_public_holiday}</td>
-              <td>${sum.deliveries != null ? sum.deliveries : "N/A"}</td>
-              <td class="${parseFloat(sum.hours_total) > 38 ? 'cell-danger' : ''}">${sum.hours_total}</td>
-              <td>${sum.age != null ? sum.age : "N/A"}</td>
-            </tr>
-          `;
-          $summaryTable.append(row)
+          // Add table information based on the selected style
+          addTableRowInformaiton(legacyStyle, sum);
         });
         // No need to update edit buttons as that is done dynamically
         setPaginationValues(req.offset, req.total); // Set pagination values
@@ -90,6 +92,43 @@ function updateSummaryTable() {
       showNotification(errorMessage, "danger");
     }
   });
+}
+
+
+function addTableRowInformaiton(legacyStyle, sum) {
+  // Set row colour based on desc priority: resigned from store (red), inactive acc (yellow), manager (blue), then white 
+  const rowColour = sum.acc_resigned ? 'table-danger' : (!sum.acc_active ? 'table-warning' : (sum.acc_manager ? 'table-info' : ''));
+
+  if (legacyStyle) {
+    const row = `
+      <tr class="${rowColour}">
+        <td class="py-2">
+          <p class="mb-1"><u><b>${sum.name}</b> (Age: ${sum.age != null ? sum.age : "N/A"})</u></p>
+          <p class="mb-1"><b>Weekday Hours:</b> ${sum.hours_weekday}</p>
+          <p class="mb-1"><b>Weekend Hours:</b> ${sum.hours_weekend}</p>
+          <p class="mb-1"><b>Public Holiday Hours:</b> ${sum.hours_public_holiday}</p>
+          <p class="mb-1"><b>Deliveries:</b> ${sum.deliveries != null ? sum.deliveries : "N/A"}</p>
+          <p class="mb-1"><span class="${parseFloat(sum.hours_total) > 38 ? 'mark' : ''}"><b>Total Hours:</b> ${sum.hours_total}</span></p>
+        </td>
+      </tr>
+    `;
+    console.log(row)
+    $('#legacySummaryTable tbody').append(row);
+
+  } else {
+    const row = `
+      <tr class="${rowColour}">
+        <td class="py-3">${sum.name}</td>
+        <td class="py-3">${sum.hours_weekday}</td>
+        <td class="py-3">${sum.hours_weekend}</td>
+        <td class="py-3">${sum.hours_public_holiday}</td>
+        <td class="py-3">${sum.deliveries != null ? sum.deliveries : "N/A"}</td>
+        <td class="py-3 ${parseFloat(sum.hours_total) > 38 ? 'cell-danger' : ''}">${sum.hours_total}</td>
+        <td class="py-3">${sum.age != null ? sum.age : "N/A"}</td>
+      </tr>
+    `;
+    $('#summaryTable tbody').append(row);
+  }
 }
 
 

--- a/src/django/auth_app/static/js/employee_dashboard.js
+++ b/src/django/auth_app/static/js/employee_dashboard.js
@@ -1,4 +1,8 @@
 $(document).ready(function() {
+  // Initial state & history set
+  updateClockedState();
+  updateShiftHistory();
+
   // Attach event to update clocked state & shift history whenever selected store changes
   $('#storeSelectDropdown').on('change', function() {
     updateClockedState();

--- a/src/django/auth_app/static/js/global.js
+++ b/src/django/auth_app/static/js/global.js
@@ -161,6 +161,19 @@ function hideSpinner() {
 }
 
 
+//////// HANDLE PASSWORD FIELD SHOWING ////////
+
+$(document).on('click', '.toggle-password', function () {
+  const $btn = $(this);
+  const $input = $btn.closest(".position-relative").find("input");
+  const isPassword = $input.attr("type") === "password";
+  const $icon = $btn.find("i");
+
+  $input.attr("type", isPassword ? "text" : "password");
+  $icon.toggleClass("fa-eye fa-eye-slash");
+});
+
+
 ////// PAGINATION CONTROLLER FUNCTIONS //////
 
 

--- a/src/django/auth_app/static/js/global.js
+++ b/src/django/auth_app/static/js/global.js
@@ -334,61 +334,6 @@ function setPaginationValues(offset, totalCount) {
 
 ///////////////////// STORE SELECTION PANEL COMPONENT FUNCTIONS /////////////////////////
 
-function populateStoreSelection() {
-  $.ajax({
-    url: `${window.djangoURLs.listAssociatedStores}`,
-    type: "GET",
-    xhrFields: {
-      withCredentials: true
-    },
-    headers: {
-      'X-CSRFToken': getCSRFToken(), // Include CSRF token
-    },
-
-    success: function(response) {
-      const $dropdown = $('#storeSelectDropdown');
-      $dropdown.empty(); // Clear previous options
-
-      const keys = Object.keys(response);
-      if (keys.length > 0) {
-        $('#storeSelectionController').removeClass('d-none'); // Ensure whole component is visible
-        keys.forEach(storeID => {
-          const storeCode = response[storeID];
-          const option = `<option value="${storeID}">${storeCode}</option>`;
-          $dropdown.append(option);
-        });
-      } else {
-        $dropdown.append('<option value="">No stores available</option>');
-        $('#storeSelectionController').removeClass('d-none');
-        showNotification("Your account has no stores associated to it. Please contact a store manager to fix this.", "danger");
-      }
-
-      // Ensure first store/option is selected (regardless if there are no stores)
-      $dropdown.prop('selectedIndex', 0);
-
-      // Hide the whole store selection component if only one store in the list
-      if (keys.length <= 1) {
-        $('#storeSelectionController').addClass('d-none');
-      }
-      
-      // Trigger initial update events linked to store selection menu
-      $dropdown.trigger('change');
-    },
-
-    error: function(jqXHR, textStatus, errorThrown) {
-      // Extract the error message from the API response if available
-      let errorMessage;
-      if (jqXHR.status == 500) {
-        errorMessage = "Failed to load associated stores due to internal server errors. Please try again.";
-      } else {
-        errorMessage = jqXHR.responseJSON?.Error || "Failed to load associated stores. Please try again.";
-      }
-      showNotification(errorMessage, "danger");
-    }
-  });
-}
-
-
 function getSelectedStoreID() {
   const storeID = $('#storeSelectDropdown').val();
 

--- a/src/django/auth_app/static/js/manage_employee_details.js
+++ b/src/django/auth_app/static/js/manage_employee_details.js
@@ -1,8 +1,8 @@
 $(document).ready(function() {
-  // Update store selection component
-  populateStoreSelection();
+  // Initial table update
+  updateEmployeeDetailsTable();
 
-  // Populate the table with all users once the stores have loaded completely
+  // Update the table with all users if user changes store
   $('#storeSelectDropdown').on('change', function() {
     updateEmployeeDetailsTable();
   });

--- a/src/django/auth_app/static/js/manage_employee_details.js
+++ b/src/django/auth_app/static/js/manage_employee_details.js
@@ -148,7 +148,8 @@ function updateEmployeeDetailsTable() {
           const activationButton = employee.is_active
             ? `<button class="actionBtn btn btn-sm btn-outline-danger" data-action="deactivate" data-id="${employee.id}"><i class="fa-solid fa-user-xmark"></i> Deactivate</button>`
             : `<button class="actionBtn btn btn-sm btn-outline-success" data-action="activate" data-id="${employee.id}"><i class="fa-solid fa-user-check"></i> Activate</button>`;
-          const rowColour = (!employee.is_active) ? 'table-danger' : '';
+          const rowColour = (!employee.is_active) ? 'table-danger' : (employee.is_manager ? 'table-info' : '');
+          console.log(employee)
 
           const row = `
             <tr class="${rowColour}">

--- a/src/django/auth_app/static/js/shift_logs.js
+++ b/src/django/auth_app/static/js/shift_logs.js
@@ -134,7 +134,7 @@ function updateShiftLogsTable() {
               <td>${shift.login_timestamp}</td>
               <td>${shift.logout_timestamp || "N/A"}</td>
               <td class="${parseInt(shift.deliveries, 10) > 0 ? 'table-warning' : ''}">${shift.deliveries}</td>
-              <td class="${parseFloat(shift.hours_worked) < 1.0 ? 'cell-danger' : (parseFloat(shift.hours_worked) > 10.0 ? 'table-danger' : '')}">${shift.hours_worked}</td>
+              <td class="${(shift.logout_time && parseFloat(shift.hours_worked) < 0.75) ? 'table-danger' : (parseFloat(shift.hours_worked) > 10.0 ? 'table-danger' : '')}">${shift.hours_worked}</td>
               <td>
                 <div class="d-flex flex-row">
                   <button class="editBtn btn btn-sm btn-outline-primary" data-id="${shift.id}"><i class="fa-solid fa-pen"></i> Edit</button>

--- a/src/django/auth_app/static/js/shift_logs.js
+++ b/src/django/auth_app/static/js/shift_logs.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
-  // Update store selection component
-  populateStoreSelection();
+  // Initial table update
+  updateShiftLogsTable();
 
   // Populate the table with all users once the stores have loaded completely
   $('#storeSelectDropdown').on('change', function() {

--- a/src/django/auth_app/templates/auth_app/account_setup.html
+++ b/src/django/auth_app/templates/auth_app/account_setup.html
@@ -18,7 +18,16 @@
           <small class="text-light-emphasis fs-6 ms-2"><em>(Optional)</em></small>
           {% endif %}
         </label>
-        {{ field }}
+
+        <div class="position-relative w-100">
+          {{ field }}
+          {% if field.field.widget.input_type == "password" %}
+          <button type="button" class="toggle-password position-absolute end-0 top-50 translate-middle-y me-2 p-0 border-0 bg-transparent text-secondary" tabindex="-1">
+            <i class="fa fa-eye cursor-pointer"></i>
+          </button>
+          {% endif %}
+        </div>
+
         {% for error in field.errors %}
           <div class="fieldError text-danger text-wrap">{{ error|escape }}</div>
         {% endfor %}

--- a/src/django/auth_app/templates/auth_app/account_setup.html
+++ b/src/django/auth_app/templates/auth_app/account_setup.html
@@ -12,7 +12,12 @@
       
       {% for field in form %}
       <div class="form-group mt-3">
-        <label for="{{ field.id_for_label }}" class="text-light">{{ field.label }}:</label>
+        <label for="{{ field.id_for_label }}" class="text-light fw-semibold w-100 d-flex flex-row align-items-center justify-content-between">
+          <span>{{ field.label }}:</span>
+          {% if not field.field.required %}
+          <small class="text-light-emphasis fs-6 ms-2"><em>(Optional)</em></small>
+          {% endif %}
+        </label>
         {{ field }}
         {% for error in field.errors %}
           <div class="fieldError text-danger text-wrap">{{ error|escape }}</div>

--- a/src/django/auth_app/templates/auth_app/account_summary.html
+++ b/src/django/auth_app/templates/auth_app/account_summary.html
@@ -100,6 +100,26 @@
   </table>
 </div>
 
+<div class="container panel rounded shadow p-3 mt-1 mb-3 ">
+  <div class="fw-bold fs-4 text-center">
+    <i class="fa-solid fa-palette me-2"></i>Colour Key
+  </div>
+  <ul class="list-unstyled mb-0 mt-1 d-flex flex-wrap justify-content-center">
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-info text-dark mb-0">&nbsp;</span>
+      Store manager account
+    </li>
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-warning text-dark mb-0">&nbsp;</span>
+      Deactivated account
+    </li>
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-danger mb-0">&nbsp;</span>
+      Account resigned from the store
+    </li>
+  </ul>
+</div>
+
 {% include "components/pagination_controller.html" %}
 {% endblock %}
 

--- a/src/django/auth_app/templates/auth_app/account_summary.html
+++ b/src/django/auth_app/templates/auth_app/account_summary.html
@@ -52,6 +52,11 @@
     <label for="ignoreNoHours" class="form-check-label">Ignore Employees With No Hours</label>
   </div>
 
+  <div class="form-check form-switch mb-4">
+    <input type="checkbox" id="legacyStyle" class="form-check-input p-2" />
+    <label for="legacyStyle" class="form-check-label">Use Legacy Table Layout</label>
+  </div>
+
   <div class="mb-4">
     <label for="filterNames" class="form-label">Filter by Employee Names (Case Insensitive)</label>
     <input type="text" id="filterNames" class="form-control" placeholder="e.g. John, Jane, Doe" />
@@ -65,7 +70,7 @@
   </div>
 </div>
 
-<!-- Shift Logs Table -->
+<!-- Summary Table -->
 <div class="table-responsive">
   <table id="summaryTable" class="table table-hover table-striped table-bordered border-dark text-center align-middle">
     <thead>
@@ -77,6 +82,18 @@
         <th>Deliveries</th>
         <th>Total Hours</th>
         <th>Age</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>
+
+<!-- LEGACY Summary Table -->
+<div class="table-responsive">
+  <table id="legacySummaryTable" class="d-none table table-hover table-striped table-bordered border-dark text-center align-middle">
+    <thead>
+      <tr>
+        <th class="fs-3">Staff Summary</th>
       </tr>
     </thead>
     <tbody></tbody>

--- a/src/django/auth_app/templates/auth_app/base.html
+++ b/src/django/auth_app/templates/auth_app/base.html
@@ -101,7 +101,6 @@
   <script>
     window.djangoURLs = {
         login: "{% url 'login' %}",
-        listAssociatedStores: "{% url 'api:list_associated_stores' %}",
         {% block extra_urls %}{% endblock %}
     };
 

--- a/src/django/auth_app/templates/auth_app/employee_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/employee_dashboard.html
@@ -39,6 +39,26 @@
     </div>
   </div>
 
+  <div class="panel rounded shadow p-3 mt-2 mb-3">
+    <div class="fw-bold fs-4 text-center">
+      <i class="fa-solid fa-palette me-2"></i>Colour Key
+    </div>
+    <ul class="list-unstyled mb-0 mt-1 d-flex flex-wrap justify-content-center">
+      <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+        <span class="badge bg-success mb-0">&nbsp;</span>
+        Active shift with no clock out recorded
+      </li>
+      <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+        <span class="badge bg-info text-dark mb-0">&nbsp;</span>
+        Shift occurred on a public holiday
+      </li>
+      <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+        <span class="badge bg-danger mb-0">&nbsp;</span>
+        Shift modified by manager
+      </li>
+    </ul>
+  </div>
+
   <div class="panel rounded shadow p-5 mt-5 text-center">
     <div id="userAccountInfo text-wrap">
       <h4 class="text-center fw-bold mb-3">Employee Details</h4>

--- a/src/django/auth_app/templates/auth_app/employee_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/employee_dashboard.html
@@ -92,15 +92,18 @@
       <div class="modal-body">
         <form id="editForm" class="px-1">
           <div class="mb-3">
-            <label for="editFirstName" class="form-label fw-semibold">First Name</label>
+            <label for="editFirstName" class="form-label fw-semibold">First Name:</label>
             <input type="text" class="form-control" id="editFirstName" name="first_name" required {% if user_first_name %}value={{ user_first_name }}{% endif %}>
           </div>
           <div class="my-3">
-            <label for="editLastName" class="form-label fw-semibold">Last Name</label>
+            <label for="editLastName" class="form-label fw-semibold">Last Name:</label>
             <input type="text" class="form-control" id="editLastName" name="last_name" required {% if user_last_name %}value={{ user_last_name }}{% endif %}>
           </div>
           <div class="my-3">
-            <label for="editPhone" class="form-label fw-semibold">Phone Number</label>
+            <label for="editPhone" class="text-light w-100 fw-semibold d-flex flex-row align-items-center justify-content-between form-label">
+              <span>Phone Number:</span>
+              <small class="text-light-emphasis fs-6 ms-2"><em>(Optional)</em></small>
+            </label>
             <input type="tel" class="form-control" id="editPhone" name="phone_number" {% if user_phone %}value={{ user_phone }}{% endif %}>
           </div>
         </form>

--- a/src/django/auth_app/templates/auth_app/login.html
+++ b/src/django/auth_app/templates/auth_app/login.html
@@ -10,6 +10,7 @@
   <form method="POST" action="{% url 'login' %}" class="login-form mt-4">
       {% csrf_token %}
       <input type="hidden" name="next" value="{{ request.GET.next }}">
+
       <div class="form-group">
         <label for="{{ form.email.id_for_label }}" class="text-light fw-semibold">Email:</label>
         {{ form.email }}
@@ -17,16 +18,24 @@
         <div class="field-error text-danger text-wrap">{{ error|escapejs }}</div>
         {% endfor %}
       </div>
+
       <div class="form-group">
         <label for="{{ form.password.id_for_label }}" class="text-light fw-semibold">Password:</label>
-        {{ form.password }}
+        <div class="position-relative w-100">
+          {{ form.password }}
+          <button type="button" class="toggle-password position-absolute end-0 top-50 translate-middle-y me-2 p-0 border-0 bg-transparent text-secondary" tabindex="-1">
+            <i class="fa fa-eye cursor-pointer"></i>
+          </button>
+        </div>
         {% for error in form.password.error %}
         <div class="field-error text-danger text-wrap">{{ error|escapejs }}</div>
         {% endfor %}
       </div>
+
       {% for error in form.non_field_errors %}
       <div class="non-field-error text-danger text-wrap">{{ error|escapejs }}</div>
       {% endfor %}
+
       <button type="submit" class="btn btn-lg btn-success w-100 p-3">Login</button>
       {% include "components/divider_OR.html" %}
       <!-- <hr class="my-2"> -->

--- a/src/django/auth_app/templates/auth_app/login.html
+++ b/src/django/auth_app/templates/auth_app/login.html
@@ -11,14 +11,14 @@
       {% csrf_token %}
       <input type="hidden" name="next" value="{{ request.GET.next }}">
       <div class="form-group">
-        <label for="{{ form.email.id_for_label }}" class="text-light">Email:</label>
+        <label for="{{ form.email.id_for_label }}" class="text-light fw-semibold">Email:</label>
         {{ form.email }}
         {% for error in form.email.errors %}
         <div class="field-error text-danger text-wrap">{{ error|escapejs }}</div>
         {% endfor %}
       </div>
       <div class="form-group">
-        <label for="{{ form.password.id_for_label }}" class="text-light">Password:</label>
+        <label for="{{ form.password.id_for_label }}" class="text-light fw-semibold">Password:</label>
         {{ form.password }}
         {% for error in form.password.error %}
         <div class="field-error text-danger text-wrap">{{ error|escapejs }}</div>

--- a/src/django/auth_app/templates/auth_app/manage_employee_details.html
+++ b/src/django/auth_app/templates/auth_app/manage_employee_details.html
@@ -38,6 +38,26 @@
   </table>
 </div>
 
+<div class="container panel rounded shadow p-3 mt-1 mb-3 ">
+  <div class="fw-bold fs-4 text-center">
+    <i class="fa-solid fa-palette me-2"></i>Colour Key
+  </div>
+  <ul class="list-unstyled mb-0 mt-1 d-flex flex-wrap justify-content-center">
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-info text-dark mb-0">&nbsp;</span>
+      Store manager account
+    </li>
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-warning text-dark mb-0">&nbsp;</span>
+      Account with no email
+    </li>
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-danger mb-0">&nbsp;</span>
+      Deactivated account
+    </li>
+  </ul>
+</div>
+
 {% include "components/pagination_controller.html" %}
 
 <!-- Edit Employee Modal -->

--- a/src/django/auth_app/templates/auth_app/manual_clocking.html
+++ b/src/django/auth_app/templates/auth_app/manual_clocking.html
@@ -21,20 +21,33 @@
       {{ form.deliveries }}
       {{ form.latitude }}
       {{ form.longitude }}
+
       <div class="form-group">
         <label for="{{ form.store_pin.id_for_label }}" class="text-light">Store PIN:</label>
-        {{ form.store_pin }}
+        <div class="position-relative w-100">
+          {{ form.store_pin }}
+          <button type="button" class="toggle-password position-absolute end-0 top-50 translate-middle-y me-2 p-0 border-0 bg-transparent text-secondary" tabindex="-1">
+            <i class="fa fa-eye cursor-pointer"></i>
+          </button>
+        </div>
         {% for error in form.store_pin.errors %}
         <div class="field-error">{{ error|escapejs }}</div>
         {% endfor %}
       </div>
+
       <div class="form-group mt-4">
         <label for="{{ form.employee_pin.id_for_label }}" class="text-light">Employee PIN:</label>
-        {{ form.employee_pin }}
-        {% for error in form.employee_pin.error %}
+        <div class="position-relative w-100">
+          {{ form.employee_pin }}
+          <button type="button" class="toggle-password position-absolute end-0 top-50 translate-middle-y me-2 p-0 border-0 bg-transparent text-secondary" tabindex="-1">
+            <i class="fa fa-eye cursor-pointer"></i>
+          </button>
+        </div>
+        {% for error in form.employee_pin.errors %}
         <div class="field-error">{{ error|escapejs }}</div>
         {% endfor %}
       </div>
+
       {% for error in form.non_field_errors %}
       <div class="nonfield-error">{{ error|escapejs }}</div>
       {% endfor %}

--- a/src/django/auth_app/templates/auth_app/shift_logs.html
+++ b/src/django/auth_app/templates/auth_app/shift_logs.html
@@ -40,6 +40,30 @@
   </table>
 </div>
 
+<div class="container panel rounded shadow p-3 mt-1 mb-3 ">
+  <div class="fw-bold fs-4 text-center">
+    <i class="fa-solid fa-palette me-2"></i>Colour Key
+  </div>
+  <ul class="list-unstyled mb-0 mt-1 d-flex flex-wrap justify-content-center">
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-success mb-0">&nbsp;</span>
+      Active shift with no logout recorded
+    </li>
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-info text-dark mb-0">&nbsp;</span>
+      Shift occurred on a public holiday
+    </li>
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-warning text-dark mb-0">&nbsp;</span>
+      Deliveries were recorded for this shift
+    </li>
+    <li class="d-flex flex-column align-items-center me-4 mb-3 mb-md-1">
+      <span class="badge bg-danger mb-0">&nbsp;</span>
+      Suspicious hours worked of &lt;0.75 or &gt;10.0 hours
+    </li>
+  </ul>
+</div>
+
 {% include "components/pagination_controller.html" %}
 
 <!-- Edit Modal -->

--- a/src/django/auth_app/templates/components/store_selection_controller.html
+++ b/src/django/auth_app/templates/components/store_selection_controller.html
@@ -1,6 +1,15 @@
-<div id="storeSelectionController" class="panel rounded shadow p-5 d-none">
+<div id="storeSelectionController" class="panel rounded shadow p-5 {% if associated_stores|length == 1 %}d-none{% endif %}">
   <label for="storeSelectDropdown" class="mb-1 fs-5">Select a store:</label>
   <select id="storeSelectDropdown" class="form-select">
-    <option value="">Loading stores...</option>
+    {% if associated_stores %}
+    {% for store_id, store_code in associated_stores.items %}
+    <option value="{{ store_id }}" {% if forloop.first %}selected{% endif %}>
+      {{ store_code }}
+    </option>
+    {% endfor %}
+
+    {% else %}
+    <option value="">No stores available</option>
+    {% endif %}
   </select>
 </div>

--- a/src/django/auth_app/templates/robots.txt
+++ b/src/django/auth_app/templates/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /admin/
+Disallow: /admin-panel/
+Disallow: /api/
+Allow: /
+
+Sitemap: {{ BASE_URL|default:'http://localhost' }}{{ SITEMAP_URL|default:'/sitemap.xml' }}

--- a/src/django/auth_app/tests/test_authorisation.py
+++ b/src/django/auth_app/tests/test_authorisation.py
@@ -134,6 +134,7 @@ def test_account_setup_success(web_client, unsetup_employee):
     data = {
         "email": unsetup_employee.email,
         "password": "NewSecurePass123",
+        "retype_password": "NewSecurePass123",
         "first_name": "UpdatedFirst",
         "last_name": "UpdatedLast",
         "phone_number": "0400000000",

--- a/src/django/auth_app/urls.py
+++ b/src/django/auth_app/urls.py
@@ -1,11 +1,20 @@
+from django.contrib.sitemaps.views import sitemap
 from django.views.generic import TemplateView
 from django.urls import path
 from auth_app import views
+
+
+sitemaps = {
+    "static": views.StaticViewSitemap(),
+}
+
 
 urlpatterns = [
     path("", views.home_directory, name="home"),
     path("manifest.json", views.manifest, name="manifest"),
     path("sw.js", views.service_worker, name="service_worker"),
+    path("robots.txt", views.robots, name="robots"),
+    path("sitemap.xml", sitemap, {"sitemaps": sitemaps}, name="sitemap"),
     path(
         "sw.js",
         TemplateView.as_view(

--- a/src/django/auth_app/views.py
+++ b/src/django/auth_app/views.py
@@ -3,6 +3,7 @@ import api.exceptions as err
 
 from django.urls import reverse
 from django.contrib import messages
+from django.contrib.sitemaps import Sitemap
 from django.shortcuts import render, redirect
 from django.core.exceptions import ValidationError
 from django.template.response import TemplateResponse
@@ -383,3 +384,30 @@ def manifest(request):
     return TemplateResponse(
         request, "manifest.json", context, content_type="application/manifest+json"
     )
+
+
+@require_GET
+@cache_control(no_cache=True, must_revalidate=True, no_store=True)
+def robots(request):
+    context = {"BASE_URL": BASE_URL, "SITEMAP_URL": reverse("sitemap")}
+
+    return TemplateResponse(request, "robots.txt", context, content_type="text/plain")
+
+
+class StaticViewSitemap(Sitemap):
+    changefreq = "weekly"
+
+    def items(self):
+        return ["home", "manual_clocking", "login"]
+
+    def location(self, item):
+        return reverse(item)
+
+    def priority(self, item):
+        if item == "home":
+            return 1.0
+        elif item == "login":
+            return 0.3
+        elif item == "manual_clocking":
+            return 0.7
+        return 0.5

--- a/src/django/auth_app/views.py
+++ b/src/django/auth_app/views.py
@@ -232,11 +232,16 @@ def manual_clocking(request):
             try:
                 if user.is_clocked_in(store=store):
                     activity = handle_clock_out(
-                        employee_id=user.id, deliveries=deliveries, store_id=store.id
+                        employee_id=user.id,
+                        deliveries=deliveries,
+                        store_id=store.id,
+                        manual=True,
                     )
                     messages.success(request, "Successfully clocked out.")
                 else:
-                    activity = handle_clock_in(employee_id=user.id, store_id=store.id)
+                    activity = handle_clock_in(
+                        employee_id=user.id, store_id=store.id, manual=True
+                    )
                     messages.success(request, "Successfully clocked in.")
             except err.NotAssociatedWithStoreError:
                 messages.error(

--- a/src/django/clock_in_system/settings.py
+++ b/src/django/clock_in_system/settings.py
@@ -22,7 +22,7 @@ def str_to_bool(value):
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#
 ######################################################
 #          PLEASE CHANGE THIS EVERY VERSION          #
-STATIC_CACHE_VER = "v1.0.4"  #
+STATIC_CACHE_VER = "v1.0.5"  #
 #  Must be increased for any change to static files  #
 ######################################################
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#

--- a/src/django/clock_in_system/settings.py
+++ b/src/django/clock_in_system/settings.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sitemaps",
     "corsheaders",
     "widget_tweaks",
     "api",

--- a/src/django/clock_in_system/settings.py
+++ b/src/django/clock_in_system/settings.py
@@ -22,7 +22,7 @@ def str_to_bool(value):
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#
 ######################################################
 #          PLEASE CHANGE THIS EVERY VERSION          #
-STATIC_CACHE_VER = "v1.0.5"  #
+STATIC_CACHE_VER = "v1.0.6"  #
 #  Must be increased for any change to static files  #
 ######################################################
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#


### PR DESCRIPTION
## Description
The main objective of this PR was to re-implement the old version of the account summary table, which has the row information going down in a column instead of across for better readability. This has been accomplished which looks like:
![image](https://github.com/user-attachments/assets/039354c1-fd30-47dc-9805-36cd9af6b747)

In addition, a duplicate password field was added to the setup page to ensure the user has typed the correct password they wish. The backend then validates that the password was indeed retyped.

To explain to store managers and other users about what the table colouring means small panels were added explaining each colour:
![image](https://github.com/user-attachments/assets/40653869-2fcd-41a3-81c9-7ab35143f05f)
![image](https://github.com/user-attachments/assets/756aabf3-575e-4101-9a6e-428ba279eaff)
etc.

I have also re-worked the way in which the store selector operates, as before the page would request via API the user's associated stores which takes up more time then needed. So to improve performance for both client and server I have moved this functionality on the server-side to be generated at page formation before its send to the user. This should also reduce the number of requests made to the API. The original API endpoint remains active for external use if required.

While I did initially want the 404 page to be pre-cached by the service worker I have now realised this cant be done as easily nor is it necessary as the page is returned in place of the expected page, so there is no specific link to the page itself to pre-cache.

## Additional Changes
I have added a robots.txt file with a sitemap.xml to help site compatibility with search engine crawlers and other such bots.

## Misc
Closes #48 