### PR TITLE
UI redesign

### DIFF
--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -3,9 +3,16 @@ body, html {
     margin: 0;
     padding: 0;
     font-family: Arial, sans-serif;
-    background-color: #1a202c; /* Dark background */
-    color: #f4f4f9;            /* Light text color */
-    min-height: 100vh;         /* Let the document grow taller than the viewport */
+    background: radial-gradient(
+        90% 90% at 50% 0%,   
+        #052D44 0%,          
+        #041D31 35%,         
+        #021021 70%,         
+        #010A19 100%         
+    );
+    background-attachment: fixed; 
+    color: #f4f4f9;            
+    min-height: 100vh;
 }
 
 .cursor-pointer {

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -859,3 +859,31 @@ table {
   transform:translateY(-2px);
   box-shadow:0 4px 10px rgba(0,0,0,.35);
 }
+
+/* Styling of the select a store dropdown */
+#storeSelectDropdown{
+  background:#1e2530;
+  border:1px solid #3b82f6;
+  color:#f4f4f9;
+  appearance:none;
+}
+#storeSelectDropdown:focus{
+  box-shadow:0 0 0 .15rem rgba(59,130,246,.5);
+  border-color:#3b82f6;
+}
+
+.select-pill-container{
+  background:transparent;
+}
+
+.select-icon,
+.select-icon i{
+  pointer-events:none;
+  color:#9ca3af;
+}
+
+#storeSelectionController,
+#storeSelectionController .select-pill-container,
+#storeSelectDropdown{
+  box-shadow:none !important;
+}

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -776,3 +776,43 @@ table {
           mask-composite:exclude;
   pointer-events:none;
 }
+
+/* ─── Generic gradient table ───────────────────────────────────────── */
+.gradient-table{
+  --grad-start:#0e3749;
+  --grad-end:#091525;
+
+
+  background:linear-gradient(135deg,var(--grad-start) 0%,var(--grad-end) 100%);
+  border-color:#1f2d3c;
+
+  border-radius:0.75rem;
+  overflow:hidden;
+}
+
+.gradient-table thead{
+  background:inherit;
+}
+
+.gradient-table thead th{
+  background:transparent !important;
+  color:#f4f4f9;
+  border-bottom:2px solid #1f2d3c;
+}
+
+/* make ordinary cells transparent so the gradient shows.
+   but leave any Bootstrap status colour (`table-*`) alone              */
+.gradient-table tbody tr:not([class*="table-"])
+               td:not([class*="table-"]){
+  background-color:transparent !important;
+  color:#f4f4f9;
+}
+
+.gradient-table.table-striped > tbody > tr:nth-of-type(odd):not([class*="table-"])
+        > td:not([class*="table-"]){
+  background-color:transparent !important;
+}
+
+/* Don't forget: Add border gradient here later on */
+.gradient-table th,
+.gradient-table td{ border-color:#1f2d3c; }

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -838,3 +838,24 @@ table {
 .gradient-panel h5{
   color:#f4f4f9;
 }
+
+/* ────────────────────────────────────────────────────────────────
+   btn-gradient  •  (generally used for 'save changes' button) 
+─────────────────────────────────────────────────────────────────*/
+.btn-gradient{
+  background:#2596be !important;   /* flat teal-blue */
+  border:none;
+  color:#fff !important;
+
+  border-radius:0.5rem;
+  box-shadow:0 2px 6px rgba(0,0,0,.25);
+  transition:transform .2s,box-shadow .2s;
+}
+
+/* subtle lift on hover / focus */
+.btn-gradient:hover,
+.btn-gradient:focus{
+  background:#2084a6 !important;   /* slightly darker */
+  transform:translateY(-2px);
+  box-shadow:0 4px 10px rgba(0,0,0,.35);
+}

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -219,6 +219,23 @@ table {
   border-radius: 50% !important;
 }
 
+/*Below code adds fade to navbar along with styling for the buttons on it and icons*/
+.che-header{
+  background: radial-gradient(
+      120% 180% at 50% 0%,
+      #011a2d 0%,
+      #001227 100%
+  );
+}
+.che-header .nav-link,
+.che-header .navbar-brand span,
+.che-header .fa-circle-user,
+.che-header .btn-light,
+.che-header .btn-light .fa-circle-user{
+  color: #29b9e4 !important;
+}
+
+
 /* If you still want the login box centered, apply flex styling only to the login container */
 .login-container {
     display: flex;

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -165,7 +165,7 @@ table {
 }
 
 .table-red {
-  background-color: #ff3b3b !important;
+  background-color: #d45e5e !important;
   color: black;
 }
 
@@ -834,8 +834,7 @@ table {
 }
 
 .gradient-panel h3,
-.gradient-panel h4,
-.gradient-panel h5{
+.gradient-panel h4{
   color:#f4f4f9;
 }
 

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -67,13 +67,13 @@ table {
 
 .card-link:hover {
   background-color: #f8f9fa !important; /* Light background */
-  color: #000 !important; /* Black text */
+  color: #fff !important;
 }
 
 .card-link:hover i,
 .card-link:hover h5,
 .card-link:hover p {
-  color: #000 !important;
+  color: #fff !important;
 }
 
 .notification-badge {

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -816,3 +816,25 @@ table {
 /* Don't forget: Add border gradient here later on */
 .gradient-table th,
 .gradient-table td{ border-color:#1f2d3c; }
+
+
+/* ────────────────────────────────────────────────────────────────
+   gradient‑panel / Add lighter gradient to divs than the background of site
+─────────────────────────────────────────────────────────────────*/
+.gradient-panel{
+  --grad-start:#0e3749;
+  --grad-end:#091525;
+
+  background:linear-gradient(135deg,var(--grad-start) 0%,var(--grad-end) 100%) !important;
+
+  border-radius:0.75rem;
+  box-shadow:0 4px 8px rgba(0,0,0,.25);
+  color:#e2e8f0;
+  border:1px solid #1f2d3c; 
+}
+
+.gradient-panel h3,
+.gradient-panel h4,
+.gradient-panel h5{
+  color:#f4f4f9;
+}

--- a/src/django/auth_app/static/css/styles.css
+++ b/src/django/auth_app/static/css/styles.css
@@ -747,3 +747,32 @@ table {
     width: auto;           /* Allow the card to size to its content, up to the max width */
     max-width: 100%;       /* Prevents the card from overflowing the cell */
 }
+
+/* Manager-dashboard tiles */
+.dashboard-tile{
+  background: linear-gradient(135deg,#01334a 0%,#020f20 100%) !important;
+  color:#fff;
+  border-radius:1rem;
+  position:relative;          /* needed for the border trick below */
+  overflow:hidden;
+  transition:transform .25s;
+}
+
+.dashboard-tile i{ color:#29b9e4 !important; }
+
+.dashboard-tile:hover{ transform:translateY(-4px); }
+
+/* gradient stroke (1 px) */
+.dashboard-tile::before{
+  content:"";
+  position:absolute; inset:0;
+  padding:1px;
+  border-radius:inherit;
+  background:linear-gradient(135deg,#265a70 0%, #17364f 100%);
+  -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+  -webkit-mask-composite:xor;
+          mask-composite:exclude;
+  pointer-events:none;
+}

--- a/src/django/auth_app/templates/auth_app/account_setup.html
+++ b/src/django/auth_app/templates/auth_app/account_setup.html
@@ -4,7 +4,7 @@
 
 {% block content_container_class %}flex-fill d-flex flex-column justify-content-center align-items-center py-5{% endblock %}
 {% block content %}
-<div class="panel rounded shadow p-5">
+<div class="panel rounded gradient-panel shadow p-5">
   <h2 class="fw-bold text-center">Setup Employee Account</h2>
   <form method="POST" action="{% url 'account_setup' %}" class="mt-4">
       {% csrf_token %}

--- a/src/django/auth_app/templates/auth_app/account_summary.html
+++ b/src/django/auth_app/templates/auth_app/account_summary.html
@@ -16,7 +16,7 @@
   {% include "components/store_selection_controller.html" %}
 </div>
 
-<div id="summaryTableController" class="container panel rounded shadow p-5 my-5">
+<div id="summaryTableController" class="container panel gradient-panel shadow p-5 my-5">
   <h3 class="mb-4 fw-semibold text-center">Table Controls</h3>
 
   <div class="row mb-3">
@@ -108,7 +108,7 @@
   </div>
 </div>
 
-<div class="container panel rounded shadow p-3 mt-1 mb-3">
+<div class="container panel gradient-panel rounded shadow p-3 mt-1 mb-3">
   <div class="fw-bold fs-4 text-center">
     <i class="fa-solid fa-palette me-2"></i>Colour Key
   </div>

--- a/src/django/auth_app/templates/auth_app/account_summary.html
+++ b/src/django/auth_app/templates/auth_app/account_summary.html
@@ -7,7 +7,7 @@
 <h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Account Summary</u></h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 </div>

--- a/src/django/auth_app/templates/auth_app/account_summary.html
+++ b/src/django/auth_app/templates/auth_app/account_summary.html
@@ -72,7 +72,7 @@
 
 <!-- Summary Table -->
 <div class="table-responsive">
-  <table id="summaryTable" class="table table-hover table-striped table-bordered border-dark text-center align-middle">
+  <table id="summaryTable" class="table table-hover table-striped table-bordered border-dark text-center align-middle gradient-table">
     <thead>
       <tr>
         <th>Staff Name</th>
@@ -90,7 +90,7 @@
 
 <!-- LEGACY Summary Table -->
 <div class="table-responsive">
-  <table id="legacySummaryTable" class="d-none table table-hover table-striped table-bordered border-dark text-center align-middle">
+  <table id="legacySummaryTable" class="d-none table table-hover table-striped table-bordered border-dark text-center align-middle gradient-table">
     <thead>
       <tr>
         <th class="fs-3">Staff Summary</th>

--- a/src/django/auth_app/templates/auth_app/account_summary.html
+++ b/src/django/auth_app/templates/auth_app/account_summary.html
@@ -4,7 +4,7 @@
 
 {% block content_container_class %}my-5{% endblock %}
 {% block content %}
-<h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Account Summary</u></h1>
+<h1 class="text-center flex-grow-1 mb-3 fw-bolder">Account Summary</h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">

--- a/src/django/auth_app/templates/auth_app/account_summary.html
+++ b/src/django/auth_app/templates/auth_app/account_summary.html
@@ -64,7 +64,7 @@
   </div>
 
   <div class="text-center">
-    <button type="button" class="btn btn-lg btn-success" id="summaryTableControllerSubmit">
+    <button type="button" class="btn btn-lg btn-gradient" id="summaryTableControllerSubmit">
       <i class="fa-solid fa-floppy-disk me-2"></i> Save Changes
     </button>
   </div>

--- a/src/django/auth_app/templates/auth_app/base.html
+++ b/src/django/auth_app/templates/auth_app/base.html
@@ -23,12 +23,12 @@
     <meta name="csrf-token" content="{{ csrf_token }}">
 </head>
 <body class="d-flex flex-column min-vh-100">
-  <nav class="navbar navbar-expand-sm navbar-dark bg-dark py-3 px-2 shadow-sm">
+   <nav class="navbar navbar-expand-sm navbar-dark che-header py-3 px-2 shadow-sm">
     <div class="container-fluid">
       <!-- Logo + Home Link -->
       <a class="navbar-brand d-flex flex-row align-items-center gap-2" href="{% url 'home' %}">
         <img src="{% static 'img/logo.png' %}" alt="Site Logo" style="height: 40px;">
-        <span class="text-white ms-3"><i class="fa-solid fa-house"></i> <u>Home</u></span>
+        <span class="ms-3"><i class="fa-solid fa-house"></i> <u>Home</u></span>
       </a>
 
       <!-- Right-side controls -->

--- a/src/django/auth_app/templates/auth_app/employee_account.html
+++ b/src/django/auth_app/templates/auth_app/employee_account.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="text-center mb-4">
-  <h1 class="fw-bolder"><u>Account Details</u></h1>
+  <h1 class="fw-bolder">Account Details</h1>
 </div>
 <div class="d-flex justify-content-between align-items-center mb-4">
   <button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary dashboard-tile">

--- a/src/django/auth_app/templates/auth_app/employee_account.html
+++ b/src/django/auth_app/templates/auth_app/employee_account.html
@@ -6,13 +6,13 @@
   <h1 class="fw-bolder"><u>Account Details</u></h1>
 </div>
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Home Directory
   </button>
 </div>
 
 <div class="d-flex justify-content-center  mt-4 mb-5">
-  <div class="panel rounded shadow p-5 text-center w-50">
+  <div class="panel rounded shadow gradient-panel p-5 text-center w-50">
     <div id="userAccountInfo" class="text-wrap">
       <h4 class="text-center fw-bold mb-3">Employee Details</h4>
       <p>
@@ -46,7 +46,7 @@
     <hr class="my-4">
 
     <div class="d-flex flex-column">
-      <button id="updateAccInfoBtn" class="btn btn-lg btn-info"><i class="fas fa-user-edit me-2"></i>Update Account Info</button>
+      <button id="updateAccInfoBtn" class="btn btn-lg btn-gradient btn-info"><i class="fas fa-user-edit me-2"></i>Update Account Info</button>
       <button id="updateAccPassBtn" class="btn btn-lg btn-danger mt-3"><i class="fas fa-key me-2"></i>Change Account Password</button>
     </div>
   </div>

--- a/src/django/auth_app/templates/auth_app/employee_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/employee_dashboard.html
@@ -5,7 +5,7 @@
 {% block content_container_class %}my-5{% endblock %}
 {% block content %}
 <div class="text-center mb-4">
-  <h1 class="fw-bolder"><u>Employee Dashboard</u></h1>
+  <h1 class="fw-bolder">Employee Dashboard</h1>
   <p class="lead">Employee: <strong>{{ request.session.name|default:"Guest" }}</strong></p>
 </div>
 

--- a/src/django/auth_app/templates/auth_app/employee_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/employee_dashboard.html
@@ -18,7 +18,7 @@
 <div class="d-flex flex-column align-items-center">
   {% include "components/store_selection_controller.html" %}
 
-  <div id="clockingContainer" class="panel rounded shadow p-5 mt-5">
+  <div id="clockingContainer" class="panel rounded gradient-panel shadow p-5 mt-5">
     <div id="clockedInInfoDiv" class="mb-3"></div>
     <button id="clockingButton" type="submit" class="btn btn-success p-3 fs-4 w-100" disabled>Clock In</button>
     <div class="deliveries flex">
@@ -29,7 +29,7 @@
   </div>
 </div>
 
-<div id="schedule-header" class="d-flex justify-content-between align-items-center mb-4 py-0 px-2 px-md-4 rounded mt-5" style="background-color: #2d3748;">
+<div id="schedule-header" class="d-flex justify-content-between gradient-panel align-items-center mb-4 py-0 px-2 px-md-4 rounded mt-5" style="background-color: #2d3748;">
   <div>
     <a class="btn btn-outline-light" href="#" id="previous-week-btn">
       <i class="fas fa-arrow-left"></i> Back
@@ -91,7 +91,7 @@
 </div>
 
 <div class="d-flex justify-content-center mt-4">
-  <div class="panel rounded shadow p-3 mt-2 mb-3 d-flex flex-column w-auto">
+  <div class="panel rounded gradient-panel shadow p-3 mt-2 mb-3 d-flex flex-column w-auto">
     <div class="fw-bold fs-4 text-center">
       <i class="fa-solid fa-palette me-2"></i>Colour Key
     </div>

--- a/src/django/auth_app/templates/auth_app/employee_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/employee_dashboard.html
@@ -10,7 +10,7 @@
 </div>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Home Directory
   </button>
 </div>

--- a/src/django/auth_app/templates/auth_app/exception_page.html
+++ b/src/django/auth_app/templates/auth_app/exception_page.html
@@ -4,7 +4,7 @@
 
 {% block content_container_class %}container-fluid py-5{% endblock %}
 {% block content %}
-<h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Store Exception Handling</u></h1>
+<h1 class="text-center flex-grow-1 mb-3 fw-bolder">Store Exception Handling</h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">

--- a/src/django/auth_app/templates/auth_app/exception_page.html
+++ b/src/django/auth_app/templates/auth_app/exception_page.html
@@ -7,7 +7,7 @@
 <h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Store Exception Handling</u></h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 </div>

--- a/src/django/auth_app/templates/auth_app/exception_page.html
+++ b/src/django/auth_app/templates/auth_app/exception_page.html
@@ -30,7 +30,7 @@
   </div>
 
   <div id="excep-page" class="col-md-9" data-type="unapproved">
-    <div class="panel rounded shadow p-4 mb-4">
+    <div class="panel rounded gradient-panel shadow p-4 mb-4">
       <h2 id="list-title" class="fw-bold text-center mb-4">Store Exceptions (0)</h2>
 
       <div id="excep-list" class="list-group">

--- a/src/django/auth_app/templates/auth_app/home_directory.html
+++ b/src/django/auth_app/templates/auth_app/home_directory.html
@@ -13,7 +13,7 @@
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center">
     {% if request.session.user_id %}
     <div class="col">
-      <a href="{% url 'dashboard' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'dashboard' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white text-decoration-none dashboard-tile">
         <div class="card-body">
           <i class="fa-solid fa-user-clock fa-2x mb-3"></i>
           <h5 class="fw-semibold card-title">Employee Dashboard</h5>
@@ -25,7 +25,7 @@
 
     {% if request.session.is_manager %}
     <div class="col">
-      <a href="{% url 'manager_dashboard' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'manager_dashboard' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white text-decoration-none dashboard-tile">
         <div class="card-body">
           <i class="fa-solid fa-clipboard-list fa-2x mb-3"></i>
           <h5 class="fw-semibold card-title">Manager Dashboard</h5>
@@ -36,7 +36,7 @@
     {% endif %}
 
     <div class="col">
-      <a href="{% url 'manual_clocking' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'manual_clocking' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white text-decoration-none dashboard-tile">
         <div class="card-body">
           <i class="fa-solid fa-keyboard fa-2x mb-3"></i>
           <h5 class="fw-semibold card-title">Manual Clock-in/out</h5>

--- a/src/django/auth_app/templates/auth_app/home_directory.html
+++ b/src/django/auth_app/templates/auth_app/home_directory.html
@@ -47,7 +47,7 @@
 
     {% if not request.session.user_id %}
     <div class="col">
-      <a href="{% url 'login' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'login' %}" class="card card-link h-100 dashboard-tile shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
         <div class="card-body">
           <i class="fa-solid fa-right-to-bracket fa-2x mb-3"></i>
           <h5 class="fw-semibold card-title">Login</h5>

--- a/src/django/auth_app/templates/auth_app/login.html
+++ b/src/django/auth_app/templates/auth_app/login.html
@@ -4,7 +4,7 @@
 
 {% block content_container_class %}flex-fill d-flex flex-column justify-content-center align-items-center py-5{% endblock %}
 {% block content %}
-<div class="panel rounded shadow p-5">
+<div class="panel rounded shadow gradient-panel p-5">
   <h2 class="fw-bold text-center">Employee Login</h2>
 
   <form method="POST" action="{% url 'login' %}" class="login-form mt-4">
@@ -39,11 +39,11 @@
       <button type="submit" class="btn btn-lg btn-success w-100 p-3">Login</button>
       {% include "components/divider_OR.html" %}
       <!-- <hr class="my-2"> -->
-      <button onclick="location.href=`{% url 'account_setup' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}`" class="btn btn-lg btn-info w-100 p-3">Setup Account</button>
+      <button onclick="location.href=`{% url 'account_setup' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}`" class="btn btn-lg btn-info btn-gradient w-100 p-3">Setup Account</button>
   </form>
 </div>
 
-<button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary mt-4">
+<button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary dashboard-tile mt-4">
   <i class="fa-solid fa-arrow-left me-2"></i> Back to Home Directory
 </button>
 {% endblock %}

--- a/src/django/auth_app/templates/auth_app/manage_employee_details.html
+++ b/src/django/auth_app/templates/auth_app/manage_employee_details.html
@@ -20,7 +20,7 @@
   {% include "components/store_selection_controller.html" %}
 </div>
 
-<div class="container panel rounded shadow p-3 my-5">
+<div class="container panel gradient-panel rounded shadow p-3 my-5">
   <button type="button"
           class="w-100 bg-transparent text-light border-0 p-1 d-flex align-items-center"
           data-bs-toggle="collapse"
@@ -88,7 +88,7 @@
   </table>
 </div>
 
-<div class="container panel rounded shadow p-3 mt-1 mb-3 ">
+<div class="container panel gradient-panel rounded shadow p-3 mt-1 mb-3 ">
   <div class="fw-bold fs-4 text-center">
     <i class="fa-solid fa-palette me-2"></i>Colour Key
   </div>

--- a/src/django/auth_app/templates/auth_app/manage_employee_details.html
+++ b/src/django/auth_app/templates/auth_app/manage_employee_details.html
@@ -4,7 +4,7 @@
 
 {% block content_container_class %}my-5{% endblock %}
 {% block content %}
-<h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Employee Details</u></h1>
+<h1 class="text-center flex-grow-1 mb-3 fw-bolder">Employee Details</h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">

--- a/src/django/auth_app/templates/auth_app/manage_employee_details.html
+++ b/src/django/auth_app/templates/auth_app/manage_employee_details.html
@@ -70,7 +70,8 @@
 </div>
 
 <div class="table-responsive">
-  <table id="employeeTable" class="table table-hover table-striped table-bordered border-dark text-center align-middle">
+  <table id="employeeTable" class="table table-hover table-striped table-bordered border-dark
+              text-center align-middle gradient-table">
       <thead>
           <tr>
               <th>Name</th>

--- a/src/django/auth_app/templates/auth_app/manage_employee_details.html
+++ b/src/django/auth_app/templates/auth_app/manage_employee_details.html
@@ -7,7 +7,7 @@
 <h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Employee Details</u></h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 

--- a/src/django/auth_app/templates/auth_app/manage_employee_details.html
+++ b/src/django/auth_app/templates/auth_app/manage_employee_details.html
@@ -11,7 +11,7 @@
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 
-  <button id="addNewEmployeeButton" class="btn btn-primary">
+  <button id="addNewEmployeeButton" class="btn dashboard-tile">
     <i class="fa-solid fa-plus me-2"></i> Add New Employee
   </button>
 </div>
@@ -61,7 +61,7 @@
       </div>
 
       <div class="text-center">
-        <button type="button" class="btn btn-lg btn-success" id="tableControllerSubmit">
+        <button type="button" class="btn btn-lg btn-gradient" id="tableControllerSubmit">
           <i class="fa-solid fa-floppy-disk me-2"></i> Save Changes
         </button>
       </div>

--- a/src/django/auth_app/templates/auth_app/manage_stores.html
+++ b/src/django/auth_app/templates/auth_app/manage_stores.html
@@ -5,7 +5,7 @@
 {% block content_container_class %}my-5{% endblock %}
 {% block content %}
 <div class="text-center mb-4">
-  <h1 class="fw-bolder"><u>Manage Associated Stores</u></h1>
+  <h1 class="fw-bolder">Manage Associated Stores</h1>
 </div>
 
 <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/django/auth_app/templates/auth_app/manage_stores.html
+++ b/src/django/auth_app/templates/auth_app/manage_stores.html
@@ -9,7 +9,7 @@
 </div>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 </div>

--- a/src/django/auth_app/templates/auth_app/manage_stores.html
+++ b/src/django/auth_app/templates/auth_app/manage_stores.html
@@ -18,7 +18,7 @@
   {% include "components/store_selection_controller.html" %}
 </div>
 
-<div class="panel rounded shadow p-5 mt-5 text-center">
+<div class="panel gradient-panel rounded shadow p-5 mt-5 text-center">
   <h3 class="fw-bolder">Store Information</h3>
   <hr>
   {% if store_info|length > 0 %}

--- a/src/django/auth_app/templates/auth_app/manage_stores.html
+++ b/src/django/auth_app/templates/auth_app/manage_stores.html
@@ -36,7 +36,7 @@
     <p><span class="fw-semibold">Store Longitude:</span> {{ info.loc_long|escape }}</p>
   </div>
   {% endfor %}
-  <button type="button" class="btn btn-lg w-100 btn-primary" id="openEditModal">
+  <button type="button" class="btn btn-lg w-100 btn-gradient" id="openEditModal">
     <i class="fas fa-pen me-1"></i> Edit Information
   </button>
   <div id="map" class="mt-4 w-100" style="height: 500px;">

--- a/src/django/auth_app/templates/auth_app/manager_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/manager_dashboard.html
@@ -74,7 +74,7 @@
   </div>
 
   <div class="text-center mt-5">
-    <a href="/" class="btn btn-outline-secondary">
+    <a href="/" class="btn btn-outline-secondary dashboard-tile">
       <i class="fa-solid fa-arrow-left me-2"></i>Back to Landing Page
     </a>
   </div>

--- a/src/django/auth_app/templates/auth_app/manager_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/manager_dashboard.html
@@ -12,7 +12,7 @@
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center">
 
     <div class="col">
-      <a href="{% url 'manage_employee_details' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'manage_employee_details' %}" class="card card-link dashboard-tile h-100 border-0 text-center text-white text-decoration-none">
         <div class="card-body">
           <i class="fa-solid fa-users fa-2x mb-3"></i>
           <h5 class="card-title">Employee Details</h5>
@@ -22,7 +22,7 @@
     </div>
     
     <div class="col">
-      <a href="{% url 'manage_shift_logs' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'manage_shift_logs' %}" class="card card-link dashboard-tile h-100 border-0 text-center text-white text-decoration-none">
         <div class="card-body">
           <i class="fa-solid fa-clock fa-2x mb-3"></i>
           <h5 class="card-title">Shift Logs</h5>
@@ -32,7 +32,7 @@
     </div>
     
     <div class="col">
-      <a href="{% url 'account_summary' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'account_summary' %}" class="card card-link dashboard-tile h-100 border-0 text-center text-white text-decoration-none">
         <div class="card-body">
           <i class="fa-solid fa-file-invoice fa-2x mb-3"></i>
           <h5 class="card-title">Account Summary</h5>
@@ -42,7 +42,7 @@
     </div>
 
     <div class="col">
-      <a href="{% url 'manage_stores' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'manage_stores' %}" class="card card-link dashboard-tile h-100 border-0 text-center text-white text-decoration-none">
         <div class="card-body">
           <i class="fa-solid fa-shop fa-2x mb-3"></i>
           <h5 class="card-title">Manage Stores</h5>
@@ -52,7 +52,7 @@
     </div>
 
     <div class="col">
-      <a href="{% url 'schedule_dashboard' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'schedule_dashboard' %}" class="card card-link dashboard-tile h-100 border-0 text-center text-white text-decoration-none">
         <div class="card-body">
           <i class="fa-solid fa-clipboard-user fa-2x mb-3"></i>
           <h5 class="card-title">Rostering</h5>
@@ -62,7 +62,7 @@
     </div>
 
     <div class="col">
-      <a href="{% url 'store_exceptions' %}" class="card card-link h-100 shadow-sm border-0 text-center text-white bg-indigo text-decoration-none">
+      <a href="{% url 'store_exceptions' %}" class="card card-link dashboard-tile h-100 border-0 text-center text-white text-decoration-none">
         <div class="card-body">
           <i class="fa-solid fa-calendar-check fa-2x mb-3"></i>
           <h5 class="card-title">Store Exceptions</h5>

--- a/src/django/auth_app/templates/auth_app/manual_clocking.html
+++ b/src/django/auth_app/templates/auth_app/manual_clocking.html
@@ -15,7 +15,7 @@
 </div>
 
 <div class="d-flex flex-column align-items-center">
-  <div class="panel rounded shadow p-5">
+  <div class="panel rounded gradient-panel shadow p-5">
     <form id="manualClockingForm" method="POST" action="{% url 'manual_clocking' %}">
       {% csrf_token %}
       {{ form.deliveries }}
@@ -54,7 +54,7 @@
     </form>
   </div>
 
-  <div class="panel rounded shadow p-5 mt-5">
+  <div class="panel rounded gradient-panel shadow p-5 mt-5">
       <button id="clockingButton" type="submit" class="btn btn-success p-3 fs-4 w-100" disabled>Clock In/Out</button>
       <div class="deliveries flex">
           <button id="minusButton" class="btn">-</button>

--- a/src/django/auth_app/templates/auth_app/manual_clocking.html
+++ b/src/django/auth_app/templates/auth_app/manual_clocking.html
@@ -9,7 +9,7 @@
 </div>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'home' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Home Directory
   </button>
 </div>

--- a/src/django/auth_app/templates/auth_app/manual_clocking.html
+++ b/src/django/auth_app/templates/auth_app/manual_clocking.html
@@ -5,7 +5,7 @@
 {% block content_container_class %}my-5{% endblock %}
 {% block content %}
 <div class="text-center mb-4">
-  <h1 class="fw-bolder"><u>Manual Clock In/Out</u></h1>
+  <h1 class="fw-bolder">Manual Clock In/Out</h1>
 </div>
 
 <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/django/auth_app/templates/auth_app/notification_page.html
+++ b/src/django/auth_app/templates/auth_app/notification_page.html
@@ -28,7 +28,7 @@
 
   <!-- Sub-Page: Account Notifications -->
   <div id="account-notifications" class="col-md-9">
-    <div class="panel rounded shadow p-4 mb-4">
+    <div class="panel rounded shadow gradient-panel p-4 mb-4">
       <h2 class="fw-bold text-center mb-4">Your <u>Unread</u> Notifications (<span id="notification-page-count">{{ notification_count }}</span>)</h2>
 
       {% if notifications.unread %}
@@ -111,7 +111,7 @@
 
   <!-- Sub-Page: ALREADY READ Account Notifications -->
   <div id="account-read-notifications" class="col-md-9">
-    <div class="panel rounded shadow p-4 mb-4">
+    <div class="panel rounded shadow gradient-panel p-4 mb-4">
       <h2 class="fw-bold text-center mb-4">Your <u>Read</u> Notifications (<span id="read-notification-page-count">{{ notifications.read_count }}</span>)</h2>
 
       {% if notifications.read %}
@@ -194,7 +194,7 @@
 
   <!-- Sub-Page: SENT Account Notifications -->
   <div id="account-sent-notifications" class="col-md-9">
-    <div class="panel rounded shadow p-4 mb-4">
+    <div class="panel rounded shadow gradient-panel p-4 mb-4">
       <h2 class="fw-bold text-center mb-4">Your <u>Sent</u> Notifications (<span id="sent-notification-page-count">{{ notifications.sent_count }}</span>)</h2>
 
       {% if notifications.sent %}
@@ -277,7 +277,7 @@
 
   <!-- Sub-Page: Send Notifications -->
   <div id="send-notification-form" class="col-md-9 d-none">
-    <div class="panel rounded shadow p-4 mb-4">
+    <div class="panel rounded shadow gradient-panel p-4 mb-4">
       <h2 class="fw-bold text-center">Send Notification</h2>
       <form method="POST" action="{% url 'notification_page' %}" class="mt-4">
         {% csrf_token %}
@@ -304,7 +304,7 @@
           {% endif %}
         {% endfor %}
 
-        <button type="submit" class="btn btn-lg btn-success w-100 p-3 mt-5">Send Notification</button>
+        <button type="submit" class="btn btn-lg btn-success btn-gradient w-100 p-3 mt-5">Send Notification</button>
 
         {% for error in form.non_field_errors %}
         <div class="nonFieldErrors text-danger text-wrap mt-2">{{ error|escape }}</div>

--- a/src/django/auth_app/templates/auth_app/schedule_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/schedule_dashboard.html
@@ -6,7 +6,7 @@
 {% block content_container_class %}my-5{% endblock %}
 
 {% block content %}
-<h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Shift Rostering</u></h1>
+<h1 class="text-center flex-grow-1 mb-3 fw-bolder">Shift Rostering</h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">

--- a/src/django/auth_app/templates/auth_app/schedule_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/schedule_dashboard.html
@@ -18,7 +18,7 @@
   {% include "components/store_selection_controller.html" %}
 </div>
 
-<div class="container panel rounded shadow p-3 my-5">
+<div class="container panel gradient-panel rounded shadow p-3 my-5">
   <button type="button"
           class="w-100 bg-transparent text-light border-0 p-1 d-flex align-items-center"
           data-bs-toggle="collapse"
@@ -105,7 +105,7 @@
   </div>
 </div>
 
-<div id="schedule-header" class="d-flex justify-content-between align-items-center mb-4 py-0 px-2 px-md-4 rounded" style="background-color: #2d3748;">
+<div id="schedule-header" class="d-flex justify-content-between gradient-panel align-items-center mb-4 py-0 px-2 px-md-4 rounded" style="background-color: #2d3748;">
   <div>
     <a class="btn btn-outline-light" href="#" id="previous-week-btn">
       <i class="fas fa-arrow-left"></i> Back
@@ -206,7 +206,7 @@
 </div>
 
 <div class="d-flex justify-content-center mt-4">
-  <div class="container panel rounded shadow p-3 px-5 mt-1 mb-3 d-flex flex-column w-auto">
+  <div class="container panel gradient-panel rounded shadow p-3 px-5 mt-1 mb-3 d-flex flex-column w-auto">
     <div class="fw-bold fs-4 text-center">
       <i class="fa-solid fa-palette me-2"></i>Colour Key
     </div>

--- a/src/django/auth_app/templates/auth_app/schedule_dashboard.html
+++ b/src/django/auth_app/templates/auth_app/schedule_dashboard.html
@@ -9,7 +9,7 @@
 <h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Shift Rostering</u></h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 </div>

--- a/src/django/auth_app/templates/auth_app/shift_logs.html
+++ b/src/django/auth_app/templates/auth_app/shift_logs.html
@@ -11,7 +11,7 @@
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 
-  <button id="addNewShiftBtn" class="btn btn-primary">
+  <button id="addNewShiftBtn" class="btn dashboard-tile">
     <i class="fa-solid fa-plus me-2"></i> Add New Shift
   </button>
 </div>
@@ -95,7 +95,7 @@
       </div>
 
       <div class="text-center">
-        <button type="button" class="btn btn-lg btn-success" id="tableControllerSubmit">
+        <button type="button" class="btn btn-lg btn-gradient" id="tableControllerSubmit">
           <i class="fa-solid fa-floppy-disk me-2"></i> Save Changes
         </button>
       </div>

--- a/src/django/auth_app/templates/auth_app/shift_logs.html
+++ b/src/django/auth_app/templates/auth_app/shift_logs.html
@@ -105,7 +105,7 @@
 
 <!-- Shift Logs Table -->
 <div class="table-responsive">
-  <table id="shiftLogsTable" class="table table-hover table-striped table-bordered border-dark text-center align-middle">
+  <table id="shiftLogsTable" class="table table-hover table-striped table-bordered border-dark text-center align-middle gradient-table">
     <thead>
       <tr>
         <th>Staff Name</th>

--- a/src/django/auth_app/templates/auth_app/shift_logs.html
+++ b/src/django/auth_app/templates/auth_app/shift_logs.html
@@ -20,7 +20,7 @@
   {% include "components/store_selection_controller.html" %}
 </div>
 
-<div class="container panel rounded shadow p-3 my-5">
+<div class="container panel gradient-panel shadow p-3 my-5">
   <button type="button"
           class="w-100 bg-transparent text-light border-0 p-1 d-flex align-items-center"
           data-bs-toggle="collapse"
@@ -123,7 +123,7 @@
   </table>
 </div>
 
-<div class="container panel rounded shadow p-3 mt-1 mb-3 ">
+<div class="container panel gradient-panel rounded shadow p-3 mt-1 mb-3 ">
   <div class="fw-bold fs-4 text-center">
     <i class="fa-solid fa-palette me-2"></i>Colour Key
   </div>

--- a/src/django/auth_app/templates/auth_app/shift_logs.html
+++ b/src/django/auth_app/templates/auth_app/shift_logs.html
@@ -7,7 +7,7 @@
 <h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Shift Logs</u></h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary">
+  <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">
     <i class="fa-solid fa-arrow-left me-2"></i> Back to Dashboard
   </button>
 

--- a/src/django/auth_app/templates/auth_app/shift_logs.html
+++ b/src/django/auth_app/templates/auth_app/shift_logs.html
@@ -4,7 +4,7 @@
 
 {% block content_container_class %}my-5{% endblock %}
 {% block content %}
-<h1 class="text-center flex-grow-1 mb-3 fw-bolder"><u>Shift Logs</u></h1>
+<h1 class="text-center flex-grow-1 mb-3 fw-bolder">Shift Logs</h1>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <button onclick="location.href=`{% url 'manager_dashboard' %}`" class="btn btn-outline-secondary dashboard-tile">

--- a/src/django/auth_app/templates/components/store_selection_controller.html
+++ b/src/django/auth_app/templates/components/store_selection_controller.html
@@ -1,15 +1,36 @@
-<div id="storeSelectionController" class="panel rounded shadow p-5 {% if associated_stores|length == 1 %}d-none{% endif %}">
-  <label for="storeSelectDropdown" class="mb-1 fs-5">Select a store:</label>
-  <select id="storeSelectDropdown" class="form-select">
-    {% if associated_stores %}
-    {% for store_id, store_code in associated_stores.items %}
-    <option value="{{ store_id }}" {% if forloop.first %}selected{% endif %}>
-      {{ store_code }}
-    </option>
-    {% endfor %}
+<div id="storeSelectionController"
+     class="panel rounded py-5 px-4 bg-transparent {% if associated_stores|length == 1 %}d-none{% endif %}">
 
-    {% else %}
-    <option value="">No stores available</option>
-    {% endif %}
-  </select>
+  <label for="storeSelectDropdown"
+         class="d-block text-center fw-semibold mb-2 fs-6 small">
+    Select a store:
+  </label>
+
+  
+  <div class="select-pill-container position-relative w-100 mx-auto" style="max-width:320px;">
+
+    <!-- left icon -->
+    <span class="select-icon position-absolute top-50 start-0 translate-middle-y ps-3">
+      <i class="fa-solid fa-shop"></i>
+    </span>
+
+    <!-- selector -->
+    <select id="storeSelectDropdown"
+            class="form-select rounded-pill ps-5 pe-5">
+      {% if associated_stores %}
+        {% for store_id, store_code in associated_stores.items %}
+          <option value="{{ store_id }}" {% if forloop.first %}selected{% endif %}>
+            {{ store_code }}
+          </option>
+        {% endfor %}
+      {% else %}
+        <option value="">No stores available</option>
+      {% endif %}
+    </select>
+
+    <!-- right chevron  -->
+    <span class="select-icon position-absolute top-50 end-0 translate-middle-y pe-3">
+      <i class="fa-solid fa-chevron-right"></i>
+    </span>
+  </div>
 </div>

--- a/src/django/clock_in_system/settings.py
+++ b/src/django/clock_in_system/settings.py
@@ -23,7 +23,7 @@ def str_to_bool(value):
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#
 ######################################################
 #          PLEASE CHANGE THIS EVERY VERSION          #
-STATIC_CACHE_VER = "v1.2.0.2"  #
+STATIC_CACHE_VER = "v1.2.0.3"  #
 #  Must be increased for any change to static files  #
 ######################################################
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#

--- a/src/django/clock_in_system/settings.py
+++ b/src/django/clock_in_system/settings.py
@@ -23,7 +23,7 @@ def str_to_bool(value):
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#
 ######################################################
 #          PLEASE CHANGE THIS EVERY VERSION          #
-STATIC_CACHE_VER = "v1.2.0.3"  #
+STATIC_CACHE_VER = "v1.2.1"  #
 #  Must be increased for any change to static files  #
 ######################################################
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#

--- a/src/django/clock_in_system/test_settings.py
+++ b/src/django/clock_in_system/test_settings.py
@@ -9,8 +9,6 @@ from .settings import *
 #                                                                 #
 ###################################################################
 
-USE_TZ = True
-TIME_ZONE = "Australia/Perth"
 
 # Override the DATABASES setting for testing
 DATABASES["default"] = {

--- a/src/django/clock_in_system/test_settings.py
+++ b/src/django/clock_in_system/test_settings.py
@@ -9,6 +9,8 @@ from .settings import *
 #                                                                 #
 ###################################################################
 
+USE_TZ = True
+TIME_ZONE = "Australia/Perth"
 
 # Override the DATABASES setting for testing
 DATABASES["default"] = {


### PR DESCRIPTION
**Major changes:**
- Global midnight gradient theme
- Replaced flat backgrounds with a “midnight glass” gradient across the whole app.

**Component‑level restyling (CSS Classes added)** 
- _dashboard-tile_ – new utility class for dashboard / homescreen buttons (also reused for back buttons).
- _gradient-panel_ – wraps key functional blocks (table controls, colour keys, etc.) with a darker glass card.
- _btn-gradient_ – unifies dark toned buttons (Edit, Save, etc.) so we can reskin them in one shot.
- _gradient-table_ – applies the gradient background through cell gaps while leaving status‑coloured rows as they are. Keeps existing colour‑key logic (deactivated users, active clock‑ins, etc.).

**Store selector changes**
New pill‑style dropdown with Font Awesome icons, centred label, and full‑width click target. Matches the new theme.

Existing colour‑key classes untouched (future pass will revise their palette to suit the darker tables, may also make these colors have a gradient to match the current design).

<img width="2534" height="1160" alt="image" src="https://github.com/user-attachments/assets/ce33b472-719c-40b9-9737-f0b132fde8f8" />
<img width="2140" height="1250" alt="image" src="https://github.com/user-attachments/assets/8a8d6c03-ca6a-43ef-b69b-e9f85182a50d" />
<img width="2298" height="1134" alt="image" src="https://github.com/user-attachments/assets/fa40c66e-569b-4ef7-abfb-2b359847c406" />
<img width="2368" height="1220" alt="image" src="https://github.com/user-attachments/assets/0e575c2a-edc3-44a6-96e2-1fc53e53f327" />

<img width="2330" height="1182" alt="image" src="https://github.com/user-attachments/assets/76be78f7-ddb5-49e6-bc2a-fdfe72ee68ec" />

<img width="2320" height="918" alt="image" src="https://github.com/user-attachments/assets/1d2ea61e-691f-4dcf-b770-1ef59b37440f" />

